### PR TITLE
added dispatcher prop to global Flux object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,11 @@ module.exports = {
 		dispatcher.dispatch(constant, payload);
 	},
 
+  /**
+   * The global dispatcher
+   */
+  dispatcher: dispatcher,
+
 	/**
 	* Mixin
 	*/


### PR DESCRIPTION
This is a pretty simple PR, but I'll let you decide as to whether or not it's a good idea or not. I've been using ReactFlux in an application of mine, and I've needed to reference the raw Dispatcher that ReactFlux is using internally.  In order to do this, I did a hack where I made a module reference the `_dispatcher` property of an unused store.

I rather like the fact that the "dispatcher" of this library is intentionally left as an implementation detail, but nevertheless, there was  scenario where I needed this.  As a result, I made this PR in case anyone else had the same needs.

If you'd like to keep this out as part of the public API, though, I completely understand. Let me know if there's any more you'd like to talk about regarding this specific change.

Thanks!

- Leland