### PR TITLE
Upgrade to Immutable.js 3

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -16,7 +16,7 @@ var StoreActionHandler = require('./storeActionHandler');
 * @param {array} handlers
 */
 var Store = function(dispatcher, storeMixin, handlers){
-	this.state = Immutable.Map({
+	this.state = Immutable.fromJS({
 		_action_states: {}
 	});
 	this._events = {};//used by store event emitter

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	"dependencies": {
 		"colors": "^1.0.3",
 		"commander": "^2.6.0",
-		"immutable": "^2.0.3",
+		"immutable": "^3.6.2",
 		"lodash-node": "~2.4.1",
 		"promise": "^6.0.1"
 	},


### PR DESCRIPTION
This upgrades to the latest version of Immutable.js.  Thankfully, migrating was pretty simple - I only had to change one line.
