### PR TITLE
Check event listeners are valid before calling

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -312,8 +312,10 @@ Store.prototype =  {
 			return;
 		}
 		var args = Array.prototype.slice.call(arguments, 1);
-		_forEach(this._events[evt], function(listner){
-			listner.apply(null, args);
+		_forEach(this._events[evt], function(listener){
+			if ('function' === typeof listener) {
+				listener.apply(null, args);
+			}
 		});
 	},
 


### PR DESCRIPTION
I ran across an issue where one of the listeners on an event would be `undefined` by the time I got to it in the `_forEach`, this would cause the _SUCCESS event to not finish (after `.setState()` which triggered the `.emit()`) and then the _AFTER event to never be called. So I would have 3 valid functions as listeners, but by the time I got to the third one it would be `undefined`. I can't seems to figure out why or how but it happened, my best guess is that a previous listener invalidated the third somehow. I have React components nested pretty deep, is it possible that unmounting a component caused a child components listener to become `undefined`?

Either way, putting this sanity check inside the `_forEach` solved the issue, and there doesn't seem to be anything else wrong with my application. Just seems like good practice.